### PR TITLE
fix: add envs.js generation to build script for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "./tools/scripts/dev.sh",
     "dev:preset": "./tools/scripts/dev.preset.sh",
     "dev:preset:sync": "tsc -p ./tools/preset-sync/tsconfig.json && node ./tools/preset-sync/index.js",
-    "build": "next build",
+    "build": "./deploy/scripts/make_envs_script.sh && next build",
     "build:next": "./deploy/scripts/download_assets.sh ./public/assets/configs && yarn svg:build-sprite && ./deploy/scripts/make_envs_script.sh && next build",
     "build:docker": "./tools/scripts/build.docker.sh",
     "start": "next start",


### PR DESCRIPTION
## Problem
When deploying to Vercel, the `build` script only runs `next build`, which doesn't generate the required `/public/assets/envs.js` file. This causes:
- 404 error when accessing `/assets/envs.js`
- Frontend unable to load environment variables at runtime
- No API requests being made
- Application not functioning properly

## Root Cause
Current `build` script in `package.json`:
```json
"build": "next build"
```

The script that generates `envs.js` is only included in `build:next`:
```json
"build:next": "./deploy/scripts/download_assets.sh ./public/assets/configs && yarn svg:build-sprite && ./deploy/scripts/make_envs_script.sh && next build"
```

## Solution
Update the `build` script to include environment script generation:
```diff
- "build": "next build",
+ "build": "./deploy/scripts/make_envs_script.sh && next build",
```

## Changes
- Modified `package.json` line 13
- Ensures `make_envs_script.sh` runs before `next build`
- All `NEXT_PUBLIC_*` environment variables are written to `/public/assets/envs.js`

## Testing
✅ Tested on Vercel deployment
✅ `/assets/envs.js` loads successfully
✅ Environment variables available in browser
✅ API requests work correctly

## Impact
- Fixes Vercel deployments
- No breaking changes for other deployment methods
- Docker deployments continue to use `build:docker`
- Local development unaffected