### PR TITLE
Fix CSP policy to allow TokenUP wallet data URI connections

### DIFF
--- a/nextjs/csp/policies/app.ts
+++ b/nextjs/csp/policies/app.ts
@@ -35,6 +35,7 @@ export function app(): CspDev.DirectiveDescriptor {
 
     'connect-src': [
       KEY_WORDS.SELF,
+      KEY_WORDS.DATA, // Allow data: URIs for @tokenup/web3kit
       ...MAIN_DOMAINS,
 
       // webpack hmr in safari doesn't recognize localhost as 'self' for some reason


### PR DESCRIPTION
## Problem
TokenUP wallet integration (@tokenup/web3kit) is blocked by CSP policy when calling `web3Kit.request()` method. 

**Error message:**
```
Refused to connect to 'data:application/json;base64,...' because it violates 
the following Content Security Policy directive: "connect-src 'self' ..."
```

**Location:** `lib/web3/tokenup.ts:46`

**Environment:** https://xone-explorer-inky.vercel.app/

## Solution
Add `data:` URI support to the `connect-src` CSP directive to allow TokenUP wallet library to use base64-encoded JSON data for communication.

## Changes
- **File:** `nextjs/csp/policies/app.ts`
- Add `KEY_WORDS.DATA` to `connect-src` array
- Include comment explaining the purpose

## Testing
- ✅ TokenUP wallet connection works properly
- ✅ No impact on other wallet functionalities
- ✅ CSP policy maintains adequate security