### PR TITLE
Add Vercel Speed Insights for performance monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@next/bundle-analyzer": "15.0.3",
     "@opentelemetry/api": "^1.4.1",
+    "@vercel/speed-insights": "^1.0.0",
     "@opentelemetry/auto-instrumentations-node": "0.43.0",
     "@opentelemetry/exporter-jaeger": "1.27.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.49.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { HTMLChakraProps } from '@chakra-ui/react';
 import { GrowthBookProvider } from '@growthbook/growthbook-react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { AppProps } from 'next/app';
 import React from 'react';
 
@@ -103,6 +104,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
                 </GrowthBookProvider>
                 <ReactQueryDevtools buttonPosition="bottom-left" position="left"/>
                 <GoogleAnalytics/>
+                <SpeedInsights/>
               </QueryClientProvider>
             </AppContextProvider>
           </Web3ModalProvider>


### PR DESCRIPTION
## Description
This PR integrates Vercel Speed Insights to enable real user monitoring (RUM) for Core Web Vitals metrics.

## Changes
- Added `@vercel/speed-insights` package to dependencies
- Integrated `SpeedInsights` component in `_app.tsx`

## Benefits
- Track real user performance metrics (LCP, FID, CLS, FCP, TTFB)
- Monitor Core Web Vitals across different pages and devices
- Identify performance bottlenecks based on actual user data
- Improve SEO rankings with better Core Web Vitals scores

## Testing
- The component only collects data in production (Vercel deployments)
- No changes to existing functionality
- Zero impact on local development

## Additional Notes
After merging, enable Speed Insights in the Vercel project dashboard to start collecting metrics.