### PR TITLE
Fix EMFILE error on Vercel deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,12 @@ const moduleExports = {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.externals.push('pino-pretty', 'lokijs', 'encoding');
 
+    // Prevent viem from importing all chain definitions to avoid EMFILE errors
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'viem/chains': false,
+    };
+
     return config;
   },
   // NOTE: all config functions should be static and not depend on any environment variables


### PR DESCRIPTION
## Problem
Vercel deployment fails with EMFILE (too many open files) errors when attempting to load the application:
```
Error: EMFILE: too many open files, open '/var/task/node_modules/viem/_esm/chains/definitions/thunderTestnet.js'
```

## Root Cause
The `viem` library includes hundreds of chain definition files in the `viem/chains` module. When deployed to Vercel's Edge Runtime, the build process attempts to load all these files, exceeding the file handle limit and causing deployment failures.

## Solution
Add a webpack alias to exclude the `viem/chains` module from the bundle. This application only uses custom chain configurations defined in the app's config files, so the built-in chain definitions are unnecessary.

## Changes
- Modified `next.config.js` webpack configuration to alias `viem/chains` to `false`
- This prevents webpack from bundling the unused chain definition files
- No impact on functionality since the app uses custom chain configs

## Testing
Verified that the application does not import from `viem/chains` anywhere in the codebase and relies entirely on custom chain definitions from app configuration.