### PR TITLE
Fix WalletConnect iframe CSP error

### DIFF
--- a/nextjs/csp/policies/walletConnect.ts
+++ b/nextjs/csp/policies/walletConnect.ts
@@ -20,10 +20,10 @@ export function walletConnect(): CspDev.DirectiveDescriptor {
       'wss://www.walletlink.org',
     ],
     'frame-ancestors': [
-      '*.walletconnect.org',
-      'secure.walletconnect.org',
-      '*.walletconnect.com',
-      'secure.walletconnect.com',
+      'https://*.walletconnect.org',
+      'https://secure.walletconnect.org',
+      'https://*.walletconnect.com',
+      'https://secure.walletconnect.com',
     ],
     'img-src': [
       KEY_WORDS.BLOB,


### PR DESCRIPTION
## Issue
Browser console shows CSP violation when WalletConnect tries to load its modal:
```
Refused to frame 'https://secure.walletconnect.org/' because an ancestor violates 
the following Content Security Policy directive: "frame-ancestors ..."
```

## Root Cause
The `frame-ancestors` directive in CSP policy was missing protocol prefix (`https://`) for WalletConnect domains.

## Fix
Updated `nextjs/csp/policies/walletConnect.ts` to include protocol in frame-ancestors URLs:
- `*.walletconnect.org` → `https://*.walletconnect.org`
- `secure.walletconnect.org` → `https://secure.walletconnect.org`

## Testing
Verified that WalletConnect modal loads without CSP errors in browser console.