### PR TITLE
Exclude viem ESM modules to prevent EMFILE errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,6 +32,7 @@ const moduleExports = {
     config.resolve.alias = {
       ...config.resolve.alias,
       'viem/chains': false,
+      'viem/_esm': false,
     };
 
     return config;


### PR DESCRIPTION
Fixes build errors caused by excessive file descriptor usage when loading viem package.

## Problem
Vercel builds were failing with EMFILE (too many open files) errors when attempting to load modules from viem's ESM directory, which contains thousands of individual module files.

## Solution
Added webpack alias to exclude `viem/_esm` from module resolution, similar to the existing exclusion for `viem/chains`. This reduces the number of files webpack needs to process during builds.

## Testing
- Verified viem functionality still works with CJS imports
- Build completes without file descriptor errors