### PR TITLE
Optimize viem imports with Next.js package optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,6 @@ const moduleExports = {
     config.resolve.alias = {
       ...config.resolve.alias,
       'viem/chains': false,
-      'viem/_esm': false,
     };
 
     return config;
@@ -48,6 +47,7 @@ const moduleExports = {
   productionBrowserSourceMaps: true,
   serverExternalPackages: ["@opentelemetry/sdk-node", "@opentelemetry/auto-instrumentations-node"],
   experimental: {
+    optimizePackageImports: ['viem'],
     staleTimes: {
       dynamic: 30,
       'static': 180,


### PR DESCRIPTION
Improves upon PR #14 by using Next.js native optimization instead of excluding ESM modules.

## Changes
- Remove `viem/_esm` exclusion from webpack alias
- Add `optimizePackageImports: ['viem']` to experimental config

## Benefits
- Properly tree-shakes viem package using Next.js built-in optimization
- Maintains full viem functionality (unlike ESM exclusion)
- Reduces bundle size by loading only imported modules
- Follows Next.js recommended practices for package optimization

## Technical Details
Next.js `optimizePackageImports` analyzes barrel file exports and transforms imports to load specific module files directly, avoiding the need to process thousands of ESM files during builds.