### PR TITLE
Add Speed Insights script hash to CSP

### DIFF
--- a/nextjs/csp/policies/app.ts
+++ b/nextjs/csp/policies/app.ts
@@ -91,6 +91,9 @@ export function app(): CspDev.DirectiveDescriptor {
 
       // CapybaraRunner
       '\'sha256-5+YTmTcBwCYdJ8Jetbr6kyjGp0Ry/H7ptpoun6CrSwQ=\'',
+
+      // Vercel Speed Insights
+      '\'sha256-WBZuTYe6IRxKrndmGrU6OaLfuAWWcWmHdqDTYPObt7g=\'',
     ],
 
     'style-src': [


### PR DESCRIPTION
Fixes 500 errors and React hydration issues caused by CSP violations.

## Problem
Site was returning 500 errors with multiple React hydration failures:
- Minified React error #418
- Minified React error #423  
- Minified React error #425

Browser console showed CSP violation blocking Speed Insights inline script.

## Root Cause
PR #8 added Vercel Speed Insights but the required script hash was missing from CSP configuration, preventing the inline script from executing and breaking React hydration.

## Changes
Added Speed Insights script hash to script-src directive in CSP policy.

## Testing
- Verified hash matches browser CSP violation report
- Checked that Speed Insights functions correctly